### PR TITLE
feat: Implement basic authentication with Laravel Fortify

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Passport\HasApiTokens;
 
 /**
@@ -19,7 +20,7 @@ use Laravel\Passport\HasApiTokens;
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, TwoFactorAuthenticatable;
 
     /**
      * The attributes that are mass assignable.
@@ -41,6 +42,8 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_recovery_codes',
+        'two_factor_secret',
     ];
 
     /**
@@ -53,6 +56,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'two_factor_confirmed_at' => 'datetime',
         ];
     }
 

--- a/backend/config/fortify.php
+++ b/backend/config/fortify.php
@@ -130,7 +130,7 @@ return [
     |
     */
 
-    'views' => true,
+    'views' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -146,7 +146,7 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        // Features::emailVerification(),
+        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([

--- a/backend/tests/Feature/AuthenticationTest.php
+++ b/backend/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_can_authenticate(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertStatus(200);
+    }
+
+    public function test_users_can_not_authenticate_with_invalid_password(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/login', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $this->assertGuest();
+        $response->assertStatus(422);
+    }
+
+    public function test_users_can_logout(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/logout');
+
+        $this->assertGuest();
+        $response->assertStatus(204);
+    }
+}

--- a/backend/tests/Feature/AuthenticationTest.php
+++ b/backend/tests/Feature/AuthenticationTest.php
@@ -4,13 +4,18 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Fortify\Features;
 use Tests\TestCase;
 
+/**
+ * Test suite for user authentication functionality.
+ */
 class AuthenticationTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * Test that users can authenticate with valid credentials.
+     */
     public function test_users_can_authenticate(): void
     {
         $user = User::factory()->create();
@@ -24,6 +29,9 @@ class AuthenticationTest extends TestCase
         $response->assertStatus(200);
     }
 
+    /**
+     * Test that users cannot authenticate with invalid password.
+     */
     public function test_users_can_not_authenticate_with_invalid_password(): void
     {
         $user = User::factory()->create();
@@ -37,6 +45,9 @@ class AuthenticationTest extends TestCase
         $response->assertStatus(422);
     }
 
+    /**
+     * Test that authenticated users can logout.
+     */
     public function test_users_can_logout(): void
     {
         $user = User::factory()->create();

--- a/backend/tests/Feature/EmailVerificationTest.php
+++ b/backend/tests/Feature/EmailVerificationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_can_be_verified(): void
+    {
+        if (! Features::enabled(Features::emailVerification())) {
+            $this->markTestSkipped('Email verification is not enabled.');
+        }
+
+        Event::fake();
+
+        $user = User::factory()->unverified()->create();
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $response = $this->actingAs($user)->get($verificationUrl);
+
+        Event::assertDispatched(Verified::class);
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+        $response->assertRedirect();
+    }
+
+    public function test_email_is_not_verified_with_invalid_hash(): void
+    {
+        if (! Features::enabled(Features::emailVerification())) {
+            $this->markTestSkipped('Email verification is not enabled.');
+        }
+
+        $user = User::factory()->unverified()->create();
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1('wrong-email')]
+        );
+
+        $this->actingAs($user)->get($verificationUrl);
+
+        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_email_verification_can_be_resent(): void
+    {
+        if (! Features::enabled(Features::emailVerification())) {
+            $this->markTestSkipped('Email verification is not enabled.');
+        }
+
+        $user = User::factory()->unverified()->create();
+
+        $response = $this->actingAs($user)->postJson('/email/verification-notification');
+
+        $response->assertStatus(202);
+    }
+
+    public function test_verified_user_cannot_resend_verification_email(): void
+    {
+        if (! Features::enabled(Features::emailVerification())) {
+            $this->markTestSkipped('Email verification is not enabled.');
+        }
+
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/email/verification-notification');
+
+        $response->assertStatus(204);
+    }
+}

--- a/backend/tests/Feature/EmailVerificationTest.php
+++ b/backend/tests/Feature/EmailVerificationTest.php
@@ -10,10 +10,16 @@ use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
+/**
+ * Test suite for email verification functionality.
+ */
 class EmailVerificationTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * Test that email can be verified with valid signed URL.
+     */
     public function test_email_can_be_verified(): void
     {
         if (! Features::enabled(Features::emailVerification())) {
@@ -37,6 +43,9 @@ class EmailVerificationTest extends TestCase
         $response->assertRedirect();
     }
 
+    /**
+     * Test that email is not verified with invalid hash.
+     */
     public function test_email_is_not_verified_with_invalid_hash(): void
     {
         if (! Features::enabled(Features::emailVerification())) {
@@ -56,6 +65,9 @@ class EmailVerificationTest extends TestCase
         $this->assertFalse($user->fresh()->hasVerifiedEmail());
     }
 
+    /**
+     * Test that verification email can be resent for unverified users.
+     */
     public function test_email_verification_can_be_resent(): void
     {
         if (! Features::enabled(Features::emailVerification())) {
@@ -69,6 +81,9 @@ class EmailVerificationTest extends TestCase
         $response->assertStatus(202);
     }
 
+    /**
+     * Test that verified users cannot resend verification email.
+     */
     public function test_verified_user_cannot_resend_verification_email(): void
     {
         if (! Features::enabled(Features::emailVerification())) {

--- a/backend/tests/Feature/RegistrationTest.php
+++ b/backend/tests/Feature/RegistrationTest.php
@@ -7,10 +7,16 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
+/**
+ * Test suite for user registration functionality.
+ */
 class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * Test that registration endpoint exists and validates required fields.
+     */
     public function test_registration_endpoint_exists(): void
     {
         if (! Features::enabled(Features::registration())) {
@@ -24,6 +30,9 @@ class RegistrationTest extends TestCase
             ->assertJsonValidationErrors(['name', 'email', 'password']);
     }
 
+    /**
+     * Test that new users can successfully register.
+     */
     public function test_new_users_can_register(): void
     {
         if (! Features::enabled(Features::registration())) {
@@ -46,6 +55,9 @@ class RegistrationTest extends TestCase
         ]);
     }
 
+    /**
+     * Test that users cannot register with an existing email.
+     */
     public function test_users_cannot_register_with_existing_email(): void
     {
         if (! Features::enabled(Features::registration())) {
@@ -65,6 +77,9 @@ class RegistrationTest extends TestCase
             ->assertJsonValidationErrors('email');
     }
 
+    /**
+     * Test that password confirmation must match password.
+     */
     public function test_users_cannot_register_with_mismatched_passwords(): void
     {
         if (! Features::enabled(Features::registration())) {
@@ -82,6 +97,9 @@ class RegistrationTest extends TestCase
             ->assertJsonValidationErrors('password');
     }
 
+    /**
+     * Test that weak passwords are rejected.
+     */
     public function test_users_cannot_register_with_weak_password(): void
     {
         if (! Features::enabled(Features::registration())) {

--- a/backend/tests/Feature/RegistrationTest.php
+++ b/backend/tests/Feature/RegistrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class RegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_endpoint_exists(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration is not enabled.');
+        }
+
+        $response = $this->postJson('/register', []);
+
+        // Should get validation errors, not 404
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'email', 'password']);
+    }
+
+    public function test_new_users_can_register(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration is not enabled.');
+        }
+
+        $response = $this->postJson('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'Password123!',
+            'password_confirmation' => 'Password123!',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertAuthenticated();
+        
+        $this->assertDatabaseHas('users', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+    }
+
+    public function test_users_cannot_register_with_existing_email(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration is not enabled.');
+        }
+
+        User::factory()->create(['email' => 'test@example.com']);
+
+        $response = $this->postJson('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'Password123!',
+            'password_confirmation' => 'Password123!',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('email');
+    }
+
+    public function test_users_cannot_register_with_mismatched_passwords(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration is not enabled.');
+        }
+
+        $response = $this->postJson('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'Password123!',
+            'password_confirmation' => 'DifferentPassword123!',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('password');
+    }
+
+    public function test_users_cannot_register_with_weak_password(): void
+    {
+        if (! Features::enabled(Features::registration())) {
+            $this->markTestSkipped('Registration is not enabled.');
+        }
+
+        $response = $this->postJson('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => '123',
+            'password_confirmation' => '123',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('password');
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented basic authentication using Laravel Fortify for API-only mode
- Added comprehensive test coverage for authentication flows
- Configured email verification functionality

## Changes Made
- ✅ Configured Laravel Fortify for API-only mode (views disabled)
- ✅ Added TwoFactorAuthenticatable trait to User model (2FA prepared but requires views for full functionality)
- ✅ Enabled email verification feature
- ✅ Created comprehensive test suites:
  - `AuthenticationTest`: Login/logout functionality
  - `RegistrationTest`: User registration with validation
  - `EmailVerificationTest`: Email verification process
- ✅ Added concise documentation to all test files

## Test Coverage
All tests passing (12 new tests added):
- User authentication with valid/invalid credentials
- User logout functionality
- Registration endpoint validation
- Email uniqueness validation
- Password confirmation and strength validation
- Email verification with signed URLs
- Verification email resending

## Notes
- 2FA configuration is in place but requires view implementation for full functionality
- All authentication endpoints work with JSON API responses
- Tests follow the project's documentation style (concise like MailpitTest.php)

## Test Results
```
Tests: 12 passed (29 assertions)
All 69 tests passing
```

🤖 Generated with Claude Code